### PR TITLE
fix: remove .env file from version control

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_API_URL='http://localhost:3003'

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration
+# Copy this file to .env and update the values
+
+VITE_API_URL='http://localhost:3003'

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+
+# Environment files
+.env
+.env.local
+.env.*.local


### PR DESCRIPTION
## Summary
Remove .env file from git tracking and add it to .gitignore to prevent sensitive environment variables from being exposed in the repository.

## Changes
- 🔒 **Security**: Removed `.env` file from git tracking
- 📝 **Git ignore**: Added `.env` and related patterns to `.gitignore`
- 📋 **Documentation**: Created `.env.example` as a template for developers

## Why this is important
Environment files often contain sensitive information like API keys, database credentials, and other secrets that should never be committed to version control. This change ensures that:
- No sensitive data is exposed in the repository history
- Developers can safely use local environment configurations
- New contributors have a template to follow

## Test plan
- [ ] Verify `.env` file is no longer tracked by git
- [ ] Confirm local `.env` file still works for development
- [ ] Check that `.env.example` provides clear guidance

🤖 Generated with [Claude Code](https://claude.ai/code)