### PR TITLE
fix: Add missing files for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="/favicon.ico">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="plugin-dev"></div>
+    <script type="module" src="index.ts"></script>
+  </body>
+</html>

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,23 @@
+// Plugin Development Environment
+import { createPluginDevelopmentEnvironment, type PluginDevConfig } from '@toplocs/plugin-sdk';
+import '@toplocs/plugin-sdk/style.css';
+
+// Import plugin configuration and components
+import pluginConfig from './src/index';
+import SidebarView from './src/views/SidebarView.vue';
+import SettingsView from './src/views/SettingsView.vue';
+import MainView from './src/views/MainView.vue';
+
+// Create development environment with plugin configuration
+const devConfig: PluginDevConfig = {
+  pluginConfig,
+  components: {
+    SidebarView,
+    SettingsView,
+    MainView
+  }
+};
+
+const app = createPluginDevelopmentEnvironment(devConfig);
+
+app.mount('#plugin-dev');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@heroicons/vue": "^2.2.0",
+    "@toplocs/plugin-sdk": "^1.0.0",
     "gun": "^0.2020.1240",
     "vue": "^3.5.12",
     "vue-router": "^4.4.5"
@@ -39,8 +40,8 @@
     "tailwindcss": "^3.4.14",
     "typescript": "~5.5.4",
     "vite": "^5.4.8",
+    "vite-plugin-top-level-await": "^1.4.4",
     "vitest": "^2.1.2",
-    "vue-tsc": "^2.1.6",
-    "vite-plugin-top-level-await": "^1.4.4"
+    "vue-tsc": "^2.1.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,26 +9,23 @@ importers:
   .:
     dependencies:
       '@heroicons/vue':
-        specifier: ^2.1.5
+        specifier: ^2.2.0
         version: 2.2.0(vue@3.5.17(typescript@5.5.4))
+      '@toplocs/plugin-sdk':
+        specifier: ^1.0.0
+        version: 1.0.0(vue-router@4.5.1(vue@3.5.17(typescript@5.5.4)))(vue@3.5.17(typescript@5.5.4))
       gun:
         specifier: ^0.2020.1240
         version: 0.2020.1241
-      vite-plugin-top-level-await:
-        specifier: ^1.4.4
-        version: 1.5.0(rollup@4.44.1)(vite@5.4.19(@types/node@20.19.4))
       vue:
         specifier: ^3.5.12
         version: 3.5.17(typescript@5.5.4)
       vue-router:
         specifier: ^4.4.5
         version: 4.5.1(vue@3.5.17(typescript@5.5.4))
-      vue3-datepicker:
-        specifier: ^0.4.0
-        version: 0.4.0(vue@3.5.17(typescript@5.5.4))
     devDependencies:
       '@originjs/vite-plugin-federation':
-        specifier: ^1.3.6
+        specifier: ^1.4.0
         version: 1.4.1
       '@tsconfig/node20':
         specifier: ^20.1.4
@@ -87,6 +84,9 @@ importers:
       vite:
         specifier: ^5.4.8
         version: 5.4.19(@types/node@20.19.4)
+      vite-plugin-top-level-await:
+        specifier: ^1.4.4
+        version: 1.5.0(rollup@4.44.1)(vite@5.4.19(@types/node@20.19.4))
       vitest:
         specifier: ^2.1.2
         version: 2.1.9(@types/node@20.19.4)(jsdom@25.0.1)
@@ -115,10 +115,6 @@ packages:
     resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/runtime@7.27.6':
-    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.0':
     resolution: {integrity: sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==}
@@ -596,6 +592,12 @@ packages:
   '@swc/types@0.1.23':
     resolution: {integrity: sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==}
 
+  '@toplocs/plugin-sdk@1.0.0':
+    resolution: {integrity: sha512-FjYG7X7SuWseo5GvITlonRotIqd6EWehz5Aej4PkkYzsMO7AoWcUESd0+5BM0LNiTCL+TEfM4859s0wA4I+xGg==}
+    peerDependencies:
+      vue: ^3.0.0
+      vue-router: ^4.0.0
+
   '@tsconfig/node20@20.1.6':
     resolution: {integrity: sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==}
 
@@ -972,10 +974,6 @@ packages:
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
-
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -1963,12 +1961,6 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue3-datepicker@0.4.0:
-    resolution: {integrity: sha512-o0/y4yuZZc0DXYhiAlX8Znrkm/zvkeYuyV9PUt0UAvwxkno2jqMS388jVUa9Ns+a2s2pOAAybyXo5uQ9YAIwVw==}
-    engines: {node: '>=10.16.0'}
-    peerDependencies:
-      vue: ^3.0.0
-
   vue@3.5.17:
     resolution: {integrity: sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==}
     peerDependencies:
@@ -2090,8 +2082,6 @@ snapshots:
   '@babel/parser@7.28.0':
     dependencies:
       '@babel/types': 7.28.0
-
-  '@babel/runtime@7.27.6': {}
 
   '@babel/types@7.28.0':
     dependencies:
@@ -2435,6 +2425,12 @@ snapshots:
   '@swc/types@0.1.23':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@toplocs/plugin-sdk@1.0.0(vue-router@4.5.1(vue@3.5.17(typescript@5.5.4)))(vue@3.5.17(typescript@5.5.4))':
+    dependencies:
+      '@originjs/vite-plugin-federation': 1.4.1
+      vue: 3.5.17(typescript@5.5.4)
+      vue-router: 4.5.1(vue@3.5.17(typescript@5.5.4))
 
   '@tsconfig/node20@20.1.6': {}
 
@@ -2881,10 +2877,6 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.27.6
 
   de-indent@1.0.2: {}
 
@@ -3903,11 +3895,6 @@ snapshots:
       '@volar/typescript': 2.4.15
       '@vue/language-core': 2.2.12(typescript@5.5.4)
       typescript: 5.5.4
-
-  vue3-datepicker@0.4.0(vue@3.5.17(typescript@5.5.4)):
-    dependencies:
-      date-fns: 2.30.0
-      vue: 3.5.17(typescript@5.5.4)
 
   vue@3.5.17(typescript@5.5.4):
     dependencies:

--- a/src/composables/eventProvider.ts
+++ b/src/composables/eventProvider.ts
@@ -154,3 +154,6 @@ export function useEventProvider(gun: any, space: string) {
     cleanup
   }
 }
+
+// Export alias for backward compatibility
+export const eventProvider = useEventProvider


### PR DESCRIPTION
## Summary
- Adds missing files required for the GitHub Pages deployment to work properly
- Mirrors the working structure from link-plugin repository

## Changes
- **Add index.html and index.ts**: Required entry points for Vite build process
- **Add @toplocs/plugin-sdk dependency**: Needed for plugin development environment
- **Add .nojekyll file**: Ensures proper GitHub Pages deployment without Jekyll processing
- **Fix eventProvider export**: Add backward compatibility alias to fix import errors

## Test plan
- [x] Build locally with `pnpm build` - builds successfully
- [ ] Deploy to GitHub Pages - should complete without errors
- [ ] Verify plugin loads correctly at deployed URL

🤖 Generated with [Claude Code](https://claude.ai/code)