### PR TITLE
fix: configure vite for GitHub Pages deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && mv dist/landing.html dist/index.html",
+    "build": "vite build && mv dist/landing.html dist/index.html && touch dist/.nojekyll",
     "preview": "pnpm build && run-p preview:plugin dev",
     "preview:plugin": "vite preview --port 3007",
     "test": "vitest",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import autoprefixer from 'autoprefixer';
 
 // Plugin configuration - supports both dev and preview modes
 export default defineConfig({
+  base: './',
   plugins: [
     vue(),
     federation({


### PR DESCRIPTION
## Summary
Fixes the GitHub Pages deployment to ensure assets load correctly when deployed to https://toplocs.github.io/event-plugin/

## Problem
The landing page was not loading correctly on GitHub Pages because asset paths were absolute (`/assets/...`) instead of relative, causing 404 errors when deployed to a subdirectory.

## Solution
- Added `base: './'` to vite.config.ts to make all asset paths relative
- Added `.nojekyll` file creation to the build script to prevent GitHub Pages from processing files with Jekyll

## Test plan
- [x] Build completes successfully
- [x] Asset paths in dist/index.html are now relative (./assets/...)
- [ ] After deployment, the landing page loads correctly with all assets

🤖 Generated with [Claude Code](https://claude.ai/code)