### PR TITLE
fix: Remove assets folder from build output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
 
   build: {
     outDir: './dist',
+    assetsDir: '',
     minify: false,
     terserOptions: {
       compress: false,


### PR DESCRIPTION
## Summary
- Aligns build configuration with link-plugin by removing the assets folder
- Changes plugin entry point from `/assets/plugin.js` to `/plugin.js`
- Sets `assetsDir: ''` in vite.config.ts

## Test plan
- [ ] Build the plugin with `pnpm build`
- [ ] Verify `dist/plugin.js` is created (not `dist/assets/plugin.js`)
- [ ] Update plugin URL in TopLocs to `https://toplocs.github.io/event-plugin/plugin.js`

🤖 Generated with [Claude Code](https://claude.ai/code)